### PR TITLE
feat(helm): add new features to helm chart

### DIFF
--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -213,13 +213,13 @@ env:
 - name: KUMA_API_SERVER_AUTH_CLIENT_CERTS_DIR
   value: /var/run/secrets/kuma.io/api-server-client-certs/
 {{- end }}
-{{- if .Values.controlPlane.tls.kdsGlobalServer.secretName }}
+{{- if or .Values.controlPlane.tls.kdsGlobalServer.secretName .Values.controlPlane.kdsGlobalServerTLSSecret.enabled }}
 - name: KUMA_MULTIZONE_GLOBAL_KDS_TLS_CERT_FILE
   value: /var/run/secrets/kuma.io/kds-server-tls-cert/tls.crt
 - name: KUMA_MULTIZONE_GLOBAL_KDS_TLS_KEY_FILE
   value: /var/run/secrets/kuma.io/kds-server-tls-cert/tls.key
 {{- end }}
-{{- if .Values.controlPlane.tls.kdsZoneClient.secretName }}
+{{- if or .Values.controlPlane.tls.kdsZoneClient.secretName .Values.controlPlane.kdsZoneClientTLSSecret.enabled }}
 - name: KUMA_MULTIZONE_ZONE_KDS_ROOT_CA_FILE
   value: /var/run/secrets/kuma.io/kds-client-tls-cert/ca.crt
 {{- end }}

--- a/deployments/charts/kuma/templates/cp-additional-k8s-secrets.yaml
+++ b/deployments/charts/kuma/templates/cp-additional-k8s-secrets.yaml
@@ -1,0 +1,16 @@
+{{ range $secret := .Values.controlPlane.additionalK8sSecrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ tpl $secret.name $ | quote }}
+  labels:
+    {{- include "kuma.labels" $ | nindent 4 }}
+    app: {{ include "kuma.name" $ }}-control-plane
+    {{ range $key, $value := $.Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
+stringData:
+  {{ range $key, $value := $secret.stringData }}
+  {{ $key | quote }}: {{ $value | quote }}
+  {{ end }}
+{{ end }}

--- a/deployments/charts/kuma/templates/cp-configmap.yaml
+++ b/deployments/charts/kuma/templates/cp-configmap.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 data:
   config.yaml: |
     # use this file to override default configuration of `kuma-cp`
@@ -26,6 +29,9 @@ metadata:
   namespace: {{ $releaseNamespace }}
   labels:
   {{- $kumaLabels | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 data:
   {{- range $fileName, $fileContents := $extraConfigMap.values }}
   {{- $fileName | nindent 2 }}: |

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -26,21 +26,10 @@ spec:
         app: {{ include "kuma.name" . }}-control-plane
     spec:
       {{- with .Values.controlPlane.affinity }}
-      affinity:
-        {{ toYaml . | nindent 8 }}
-      {{- else }}
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - {{ include "kuma.name" . }}-control-plane
-              topologyKey: kubernetes.io/hostname
+      affinity: {{ tpl (toYaml . | nindent 8) $ }}
+      {{- end }}
+      {{- with .Values.controlPlane.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ tpl (toYaml . | nindent 8) $ }}
       {{- end }}
       {{- if .Values.controlPlane.podSecurityContext }}
       securityContext:

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -94,11 +94,8 @@ spec:
             - containerPort: 5681
             - containerPort: 5682
             - containerPort: 5443
-            {{- if ne .Values.controlPlane.mode "global" }}
-            - containerPort: 5678
-            - containerPort: 5653
-              protocol: UDP
-          {{- end }}
+            # For the global zone sync service
+            - containerPort: 5685
           livenessProbe:
             httpGet:
               path: /healthy

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
     app: {{ include "kuma.name" . }}-control-plane
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   replicas: {{ .Values.controlPlane.replicas }}
   strategy:
@@ -24,6 +27,9 @@ spec:
       labels:
         {{- include "kuma.selectorLabels" . | nindent 8 }}
         app: {{ include "kuma.name" . }}-control-plane
+        {{ range $key, $value := .Values.controlPlane.extraLabels }}
+        {{ $key | quote }}: {{ $value | quote }}
+        {{ end }}
     spec:
       {{- with .Values.controlPlane.affinity }}
       affinity: {{ tpl (toYaml . | nindent 8) $ }}

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -1,3 +1,11 @@
+{{ $kdsGlobalServerTLSSecretName := .Values.controlPlane.tls.kdsGlobalServer.secretName }}
+{{ if and .Values.controlPlane.kdsGlobalServerTLSSecret.enabled (eq $kdsGlobalServerTLSSecretName "") }}
+{{ $kdsGlobalServerTLSSecretName = print (include "kuma.name" .) "-kds-global-server-tls" }}
+{{ end }}
+{{ $kdsZoneClientTLSSecretName := .Values.controlPlane.tls.kdsZoneClient.secretName }}
+{{ if and .Values.controlPlane.kdsZoneClientTLSSecret.enabled (eq $kdsZoneClientTLSSecretName "") }}
+{{ $kdsZoneClientTLSSecretName = print (include "kuma.name" .) "-kds-zone-client-tls" }}
+{{ end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -146,12 +154,12 @@ spec:
               mountPath: /var/run/secrets/kuma.io/api-server-client-certs
               readOnly: true
           {{- end }}
-          {{- if .Values.controlPlane.tls.kdsGlobalServer.secretName }}
+          {{- if $kdsGlobalServerTLSSecretName }}
             - name: kds-server-tls-cert
               mountPath: /var/run/secrets/kuma.io/kds-server-tls-cert
               readOnly: true
           {{- end }}
-          {{- if .Values.controlPlane.tls.kdsZoneClient.secretName }}
+          {{- if $kdsZoneClientTLSSecretName }}
             - name: kds-client-tls-cert
               mountPath: /var/run/secrets/kuma.io/kds-client-tls-cert
               readOnly: true
@@ -191,15 +199,15 @@ spec:
           secret:
             secretName: {{ .Values.controlPlane.tls.apiServer.clientCertsSecretName }}
         {{- end }}
-        {{- if .Values.controlPlane.tls.kdsGlobalServer.secretName }}
+        {{- if $kdsGlobalServerTLSSecretName }}
         - name: kds-server-tls-cert
           secret:
-            secretName: {{ .Values.controlPlane.tls.kdsGlobalServer.secretName }}
+            secretName: {{ $kdsGlobalServerTLSSecretName }}
         {{- end }}
-        {{- if .Values.controlPlane.tls.kdsZoneClient.secretName }}
+        {{- if $kdsZoneClientTLSSecretName }}
         - name: kds-client-tls-cert
           secret:
-            secretName: {{ .Values.controlPlane.tls.kdsZoneClient.secretName }}
+            secretName: {{ $kdsZoneClientTLSSecretName }}
         {{- end }}
         - name: {{ include "kuma.name" . }}-control-plane-config
           configMap:

--- a/deployments/charts/kuma/templates/cp-global-sync-service.yaml
+++ b/deployments/charts/kuma/templates/cp-global-sync-service.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.controlPlane.mode "global" }}
+{{- if or (and (eq .Values.controlPlane.mode "global") (eq .Values.controlPlane.globalZoneSyncService.enabled nil)) .Values.controlPlane.globalZoneSyncService.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,4 +22,4 @@ spec:
   selector:
     app: {{ include "kuma.name" . }}-control-plane
   {{ include "kuma.selectorLabels" . | nindent 4 }}
-  {{- end }}
+{{- end }}

--- a/deployments/charts/kuma/templates/cp-global-sync-service.yaml
+++ b/deployments/charts/kuma/templates/cp-global-sync-service.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- range $key, $value := .Values.controlPlane.globalZoneSyncService.annotations }}
       {{ $key }}: {{ $value | quote }}
     {{- end }}
+  labels:
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   type: {{ .Values.controlPlane.globalZoneSyncService.type }}
   {{- if .Values.controlPlane.globalZoneSyncService.loadBalancerIP }}

--- a/deployments/charts/kuma/templates/cp-hpa.yaml
+++ b/deployments/charts/kuma/templates/cp-hpa.yaml
@@ -1,12 +1,16 @@
 {{- if .Values.controlPlane.autoscaling.enabled }}
-{{- $supportsV2Beta2 := .Capabilities.APIVersions.Has "autoscaling/v2beta2" }}
-apiVersion: {{ $supportsV2Beta2 | ternary "autoscaling/v2beta2" "autoscaling/v1" }}
+{{ if .Capabilities.APIVersions.Has "autoscaling/v2beta2" }}
+apiVersion: "autoscaling/v2beta2"
+{{ else }}
+apiVersion: "autoscaling/v1"
+{{ end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kuma.name" . }}-control-plane
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
+    app: {{ include "kuma.name" . }}-control-plane
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -14,10 +18,9 @@ spec:
     name: {{ include "kuma.name" . }}-control-plane
   minReplicas: {{ .Values.controlPlane.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.controlPlane.autoscaling.maxReplicas }}
-  {{- if not $supportsV2Beta2 }}
+  {{ if .Capabilities.APIVersions.Has "autoscaling/v2beta2" }}
+  metrics: {{- toYaml .Values.controlPlane.autoscaling.metrics | nindent 4 }}
+  {{ else }}
   targetCPUUtilizationPercentage: {{ .Values.controlPlane.autoscaling.targetCPUUtilizationPercentage }}
-  {{- else }}
-  metrics:
-  {{- toYaml .Values.controlPlane.autoscaling.metrics | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/deployments/charts/kuma/templates/cp-hpa.yaml
+++ b/deployments/charts/kuma/templates/cp-hpa.yaml
@@ -11,6 +11,9 @@ metadata:
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
     app: {{ include "kuma.name" . }}-control-plane
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/deployments/charts/kuma/templates/cp-kds-global-server-secret.yaml
+++ b/deployments/charts/kuma/templates/cp-kds-global-server-secret.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.controlPlane.kdsGlobalServerTLSSecret.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kuma.name" . }}-kds-global-server-tls
+  labels:
+    {{- include "kuma.labels" . | nindent 4 }}
+    app: {{ include "kuma.name" . }}-control-plane
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
+type: kubernetes.io/tls
+stringData:
+  tls.crt: {{ .Values.controlPlane.kdsGlobalServerTLSSecret.cert | quote }}
+  tls.key: {{ .Values.controlPlane.kdsGlobalServerTLSSecret.key | quote }}
+{{ end }}

--- a/deployments/charts/kuma/templates/cp-kds-zone-client-tls-secret.yaml
+++ b/deployments/charts/kuma/templates/cp-kds-zone-client-tls-secret.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.controlPlane.kdsZoneClientTLSSecret.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kuma.name" . }}-kds-zone-client-tls
+  labels:
+    {{- include "kuma.labels" . | nindent 4 }}
+    app: {{ include "kuma.name" . }}-control-plane
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
+stringData:
+  ca.crt: {{ .Values.controlPlane.kdsZoneClientTLSSecret.cert | quote }}
+{{ end }}

--- a/deployments/charts/kuma/templates/cp-pdb.yaml
+++ b/deployments/charts/kuma/templates/cp-pdb.yaml
@@ -1,0 +1,22 @@
+{{ if $.Values.controlPlane.podDisruptionBudget.enabled }}
+{{ if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{ else if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+apiVersion: policy/v1beta1
+{{ else }}
+{{ fail "pod disruption budgets are not supported by this version of kubernetes" }}
+{{ end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kuma.name" . }}-control-plane
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kuma.labels" . | nindent 4 }}
+    app: {{ include "kuma.name" . }}-control-plane
+spec:
+  maxUnavailable: {{ .Values.controlPlane.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "kuma.selectorLabels" . | nindent 6 }}
+      app: {{ include "kuma.name" . }}-control-plane
+{{ end }}

--- a/deployments/charts/kuma/templates/cp-pdb.yaml
+++ b/deployments/charts/kuma/templates/cp-pdb.yaml
@@ -13,6 +13,9 @@ metadata:
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
     app: {{ include "kuma.name" . }}-control-plane
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   maxUnavailable: {{ .Values.controlPlane.podDisruptionBudget.maxUnavailable }}
   selector:

--- a/deployments/charts/kuma/templates/cp-rbac.yaml
+++ b/deployments/charts/kuma/templates/cp-rbac.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- range . }}
@@ -18,6 +21,9 @@ metadata:
   name: {{ include "kuma.name" . }}-control-plane
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 rules:
   - apiGroups:
       - ""
@@ -255,6 +261,9 @@ metadata:
   name: {{ include "kuma.name" . }}-control-plane
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -271,6 +280,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 rules:
   - apiGroups:
       - ""
@@ -302,6 +314,10 @@ kind: RoleBinding
 metadata:
   name: {{ include "kuma.name" . }}-control-plane
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deployments/charts/kuma/templates/cp-service.yaml
+++ b/deployments/charts/kuma/templates/cp-service.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.controlPlane.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -35,3 +36,4 @@ spec:
   selector:
     app: {{ include "kuma.name" . }}-control-plane
   {{- include "kuma.selectorLabels" . | nindent 4 }}
+{{ end }}

--- a/deployments/charts/kuma/templates/cp-service.yaml
+++ b/deployments/charts/kuma/templates/cp-service.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "5680"

--- a/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
+++ b/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
@@ -42,6 +42,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 data:
   tls.crt: {{ $cert }}
   tls.key: {{ $key }}
@@ -55,6 +58,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{ include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 webhooks:
   - name: mesh.defaulter.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
@@ -180,6 +186,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{ include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 webhooks:
   - name: validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]

--- a/deployments/charts/kuma/templates/egress-deployment.yaml
+++ b/deployments/charts/kuma/templates/egress-deployment.yaml
@@ -31,21 +31,10 @@ spec:
         app: {{ include "kuma.name" . }}-egress
     spec:
       {{- with .Values.egress.affinity }}
-      affinity:
-        {{ toYaml . | nindent 8 }}
-      {{- else }}
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - {{ include "kuma.name" . }}-egress
-              topologyKey: kubernetes.io/hostname
+      affinity: {{ tpl (toYaml . | nindent 8) $ }}
+      {{- end }}
+      {{- with .Values.egress.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ tpl (toYaml . | nindent 8) $ }}
       {{- end }}
       {{- if .Values.egress.podSecurityContext }}
       securityContext:

--- a/deployments/charts/kuma/templates/egress-deployment.yaml
+++ b/deployments/charts/kuma/templates/egress-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
     app: {{ include "kuma.name" . }}-egress
+    {{ range $key, $value := .Values.egress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   strategy:
     rollingUpdate:
@@ -29,6 +32,9 @@ spec:
       labels:
         {{- include "kuma.selectorLabels" . | nindent 8 }}
         app: {{ include "kuma.name" . }}-egress
+        {{ range $key, $value := .Values.egress.extraLabels }}
+        {{ $key | quote }}: {{ $value | quote }}
+        {{ end }}
     spec:
       {{- with .Values.egress.affinity }}
       affinity: {{ tpl (toYaml . | nindent 8) $ }}

--- a/deployments/charts/kuma/templates/egress-hpa.yaml
+++ b/deployments/charts/kuma/templates/egress-hpa.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.egress.autoscaling.enabled }}
+{{ if .Capabilities.APIVersions.Has "autoscaling/v2beta2" }}
+apiVersion: "autoscaling/v2beta2"
+{{ else }}
+apiVersion: "autoscaling/v1"
+{{ end }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "kuma.name" . }}-egress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kuma.labels" . | nindent 4 }}
+    app: kuma-egress
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "kuma.name" . }}-egress
+  minReplicas: {{ .Values.egress.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.egress.autoscaling.maxReplicas }}
+  {{ if .Capabilities.APIVersions.Has "autoscaling/v2beta2" }}
+  metrics: {{- toYaml .Values.egress.autoscaling.metrics | nindent 4 }}
+  {{ else }}
+  targetCPUUtilizationPercentage: {{ .Values.egress.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/deployments/charts/kuma/templates/egress-hpa.yaml
+++ b/deployments/charts/kuma/templates/egress-hpa.yaml
@@ -11,6 +11,9 @@ metadata:
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
     app: kuma-egress
+    {{ range $key, $value := .Values.egress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/deployments/charts/kuma/templates/egress-pdb.yaml
+++ b/deployments/charts/kuma/templates/egress-pdb.yaml
@@ -1,0 +1,22 @@
+{{ if $.Values.egress.podDisruptionBudget.enabled }}
+{{ if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{ else if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+apiVersion: policy/v1beta1
+{{ else }}
+{{ fail "pod disruption budgets are not supported by this version of kubernetes" }}
+{{ end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kuma.name" . }}-egress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kuma.labels" . | nindent 4 }}
+    app: kuma-egress
+spec:
+  maxUnavailable: {{ .Values.egress.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "kuma.selectorLabels" . | nindent 6 }}
+      app: kuma-egress
+{{ end }}

--- a/deployments/charts/kuma/templates/egress-pdb.yaml
+++ b/deployments/charts/kuma/templates/egress-pdb.yaml
@@ -13,6 +13,9 @@ metadata:
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
     app: kuma-egress
+    {{ range $key, $value := .Values.egress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   maxUnavailable: {{ .Values.egress.podDisruptionBudget.maxUnavailable }}
   selector:

--- a/deployments/charts/kuma/templates/egress-rbac.yaml
+++ b/deployments/charts/kuma/templates/egress-rbac.yaml
@@ -6,4 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.egress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 {{- end }}

--- a/deployments/charts/kuma/templates/egress-service.yaml
+++ b/deployments/charts/kuma/templates/egress-service.yaml
@@ -2,6 +2,7 @@
 {{- if eq .Values.controlPlane.mode "global" }}
 {{ fail "You shouldn't run zoneEgress when running the CP in global" }}
 {{- end }}
+{{- if and .Values.egress.enabled .Values.egress.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deployments/charts/kuma/templates/egress-service.yaml
+++ b/deployments/charts/kuma/templates/egress-service.yaml
@@ -10,6 +10,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.egress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
   annotations:
     {{- range $key, $value := .Values.egress.service.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -103,13 +103,7 @@ spec:
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 3
-          resources:
-            requests:
-              cpu: 50m
-              memory: 64Mi
-            limits:
-              cpu: 1000m
-              memory: 512Mi
+          resources: {{ toYaml .Values.ingress.resources | nindent 12 }}
           volumeMounts:
             - name: {{ include "kuma.name" . }}-tls-cert
               mountPath: /var/run/secrets/kuma.io/tls-cert

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
     app: {{ include "kuma.name" . }}-ingress
+    {{ range $key, $value := .Values.ingress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   strategy:
     rollingUpdate:
@@ -29,6 +32,9 @@ spec:
       labels:
         {{- include "kuma.selectorLabels" . | nindent 8 }}
         app: {{ include "kuma.name" . }}-ingress
+        {{ range $key, $value := .Values.ingress.extraLabels }}
+        {{ $key | quote }}: {{ $value | quote }}
+        {{ end }}
     spec:
       {{- with .Values.ingress.affinity }}
       affinity: {{ tpl (toYaml . | nindent 8) $ }}

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -31,21 +31,10 @@ spec:
         app: {{ include "kuma.name" . }}-ingress
     spec:
       {{- with .Values.ingress.affinity }}
-      affinity:
-        {{ toYaml . | nindent 8 }}
-      {{- else }}
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - {{ include "kuma.name" . }}-ingress
-              topologyKey: kubernetes.io/hostname
+      affinity: {{ tpl (toYaml . | nindent 8) $ }}
+      {{- end }}
+      {{- with .Values.ingress.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ tpl (toYaml . | nindent 8) $ }}
       {{- end }}
       {{- if .Values.ingress.podSecurityContext }}
       securityContext:

--- a/deployments/charts/kuma/templates/ingress-hpa.yaml
+++ b/deployments/charts/kuma/templates/ingress-hpa.yaml
@@ -11,6 +11,9 @@ metadata:
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
     app: kuma-ingress
+    {{ range $key, $value := .Values.ingress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/deployments/charts/kuma/templates/ingress-hpa.yaml
+++ b/deployments/charts/kuma/templates/ingress-hpa.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.ingress.autoscaling.enabled }}
+{{ if .Capabilities.APIVersions.Has "autoscaling/v2beta2" }}
+apiVersion: "autoscaling/v2beta2"
+{{ else }}
+apiVersion: "autoscaling/v1"
+{{ end }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "kuma.name" . }}-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kuma.labels" . | nindent 4 }}
+    app: kuma-ingress
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "kuma.name" . }}-ingress
+  minReplicas: {{ .Values.ingress.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.ingress.autoscaling.maxReplicas }}
+  {{ if .Capabilities.APIVersions.Has "autoscaling/v2beta2" }}
+  metrics: {{- toYaml .Values.ingress.autoscaling.metrics | nindent 4 }}
+  {{ else }}
+  targetCPUUtilizationPercentage: {{ .Values.ingress.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/deployments/charts/kuma/templates/ingress-pdb.yaml
+++ b/deployments/charts/kuma/templates/ingress-pdb.yaml
@@ -13,6 +13,9 @@ metadata:
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
     app: kuma-ingress
+    {{ range $key, $value := .Values.ingress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   maxUnavailable: {{ .Values.ingress.podDisruptionBudget.maxUnavailable }}
   selector:

--- a/deployments/charts/kuma/templates/ingress-pdb.yaml
+++ b/deployments/charts/kuma/templates/ingress-pdb.yaml
@@ -1,0 +1,22 @@
+{{ if $.Values.ingress.podDisruptionBudget.enabled }}
+{{ if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{ else if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+apiVersion: policy/v1beta1
+{{ else }}
+{{ fail "pod disruption budgets are not supported by this version of kubernetes" }}
+{{ end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kuma.name" . }}-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kuma.labels" . | nindent 4 }}
+    app: kuma-ingress
+spec:
+  maxUnavailable: {{ .Values.ingress.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "kuma.selectorLabels" . | nindent 6 }}
+      app: kuma-ingress
+{{ end }}

--- a/deployments/charts/kuma/templates/ingress-rbac.yaml
+++ b/deployments/charts/kuma/templates/ingress-rbac.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.ingress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- range . }}

--- a/deployments/charts/kuma/templates/ingress-service.yaml
+++ b/deployments/charts/kuma/templates/ingress-service.yaml
@@ -10,6 +10,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.ingress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
   annotations:
     {{- range $key, $value := .Values.ingress.service.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/deployments/charts/kuma/templates/ingress-service.yaml
+++ b/deployments/charts/kuma/templates/ingress-service.yaml
@@ -2,6 +2,7 @@
 {{- if or (eq .Values.controlPlane.mode "global") (eq .Values.controlPlane.mode "standalone") }}
 {{ fail "You shouldn't run zoneIngress when running the CP in global or standalone" }}
 {{- end }}
+{{- if and .Values.ingress.enabled .Values.ingress.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -362,6 +362,15 @@ ingress:
   # -- Number of replicas of the Ingress. Ignored when autoscaling is enabled.
   replicas: 1
 
+  # -- Define the resources to allocate to mesh ingress
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+
   # Horizontal Pod Autoscaling configuration
   autoscaling:
     # -- Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -18,6 +18,9 @@ installCrdsOnUpgrade:
   imagePullSecrets: []
 
 controlPlane:
+  # -- Labels to add to resources in addition to default labels
+  extraLabels: {}
+
   # -- Kuma CP log level: one of off,info,debug
   logLevel: "info"
 
@@ -320,6 +323,10 @@ dataPlane:
 ingress:
   # -- If true, it deploys Ingress for cross cluster communication
   enabled: false
+
+  # -- Labels to add to resources, in addition to default labels
+  extraLabels: {}
+
   # -- Time for which old listener will still be active as draining
   drainTime: 30s
 
@@ -429,6 +436,8 @@ ingress:
 egress:
   # -- If true, it deploys Egress for cross cluster communication
   enabled: false
+  # -- Labels to add to resources, in addition to the default labels.
+  extraLabels: {}
   # -- Time for which old listener will still be active as draining
   drainTime: 30s
   # -- Number of replicas of the Egress. Ignored when autoscaling is enabled.

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -93,7 +93,6 @@ controlPlane:
           topologyKey: kubernetes.io/hostname
 
   # -- Topology spread constraints rule for the Kuma Control Plane pods
-  # Don't set this and affinity at the same time
   # This is rendered as a template so you can use variables to generate match labels.
   topologySpreadConstraints:
 
@@ -444,7 +443,6 @@ ingress:
           topologyKey: kubernetes.io/hostname
 
   # -- Topology spread constraints rule for the Kuma Mesh Ingress pods
-  # Don't set this and affinity at the same time
   # This is rendered as a template so you can use variables to generate match labels.
   topologySpreadConstraints:
 
@@ -554,7 +552,6 @@ egress:
           topologyKey: kubernetes.io/hostname
 
   # -- Topology spread constraints rule for the Kuma Egress pods
-  # Don't set this and affinity at the same time
   # This is rendered as a template so you can use variables to generate match labels.
   topologySpreadConstraints:
 

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -94,6 +94,7 @@ controlPlane:
 
   # -- Topology spread constraints rule for the Kuma Control Plane pods
   # Don't set this and affinity at the same time
+  # This is rendered as a template so you can use variables to generate match labels.
   topologySpreadConstraints:
 
   # -- Failure policy of the mutating webhook implemented by the Kuma Injector component
@@ -176,10 +177,28 @@ controlPlane:
       clientCertsSecretName: ""
     kdsGlobalServer:
       # -- Secret that contains tls.crt, tls.key for protecting cross cluster communication
+      # If kdsGlobalServerTLSSecret is enabled, the generated secret's name
+      # will be used by default, and this would override it.
       secretName: ""
     kdsZoneClient:
       # -- Secret that contains ca.crt which was used to sign KDS Global server. Used for CP verification
+      # If kdsZoneClientTLSSecret is enabled, the generated secret's name will
+      # be used by default, and this would override it.
       secretName: ""
+
+  kdsGlobalServerTLSSecret:
+    # -- Whether or not to create the global server secret. Leave set to false if you created the secret manually.
+    enabled: false
+    # -- The TLS certificate to offer
+    cert: ""
+    # -- The TLS key to use
+    key: ""
+
+  kdsZoneClientTLSSecret:
+    # -- Whether or not to create the zone client secret. Leave set to false if you created the secret manually.
+    enabled: false
+    # -- The TLS certificate to expect
+    cert: ""
 
   image:
     # -- Kuma CP ImagePullPolicy
@@ -407,6 +426,7 @@ ingress:
 
   # -- Topology spread constraints rule for the Kuma Mesh Ingress pods
   # Don't set this and affinity at the same time
+  # This is rendered as a template so you can use variables to generate match labels.
   topologySpreadConstraints:
 
   # -- Security context at the pod level for ingress
@@ -516,6 +536,7 @@ egress:
 
   # -- Topology spread constraints rule for the Kuma Egress pods
   # Don't set this and affinity at the same time
+  # This is rendered as a template so you can use variables to generate match labels.
   topologySpreadConstraints:
 
   # -- Security context at the pod level for egress

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -97,6 +97,9 @@ controlPlane:
   injectorFailurePolicy: Fail
 
   service:
+    # -- Whether or not to create a service resource.
+    enabled: true
+
     # -- (string) Optionally override of the Kuma Control Plane Service's name
     name:
 
@@ -124,6 +127,9 @@ controlPlane:
 
   # -- URL of Global Kuma CP
   globalZoneSyncService:
+    # -- Whether or not to create a k8s service for the global zone sync
+    # service. If null, it will be created only if mode is set to global.
+    enabled: null
     # -- Service type of the Global-zone sync
     type: LoadBalancer
     # -- (string) Optionally specify IP to be used by cloud provider when configuring load balancer
@@ -342,6 +348,8 @@ ingress:
             averageUtilization: 80
 
   service:
+    # -- Whether or not to create a Service resource.
+    enabled: true
     # -- Service type of the Ingress
     type: LoadBalancer
     # -- (string) Optionally specify IP to be used by cloud provider when configuring load balancer
@@ -448,6 +456,8 @@ egress:
             averageUtilization: 80
 
   service:
+    # -- Whether or not to create the service object
+    enabled: true
     # -- Service type of the Egress
     type: ClusterIP
     # -- (string) Optionally specify IP to be used by cloud provider when configuring load balancer

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -316,8 +316,31 @@ ingress:
   enabled: false
   # -- Time for which old listener will still be active as draining
   drainTime: 30s
-  # -- Number of replicas of the Ingress
+
+  # -- Number of replicas of the Ingress. Ignored when autoscaling is enabled.
   replicas: 1
+
+  # Horizontal Pod Autoscaling configuration
+  autoscaling:
+    # -- Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster
+    enabled: false
+
+    # -- The minimum CP pods to allow
+    minReplicas: 2
+    # -- The max CP pods to scale to
+    maxReplicas: 5
+
+    # -- For clusters that don't support autoscaling/v2beta, autoscaling/v1 is used
+    targetCPUUtilizationPercentage: 80
+    # -- For clusters that do support autoscaling/v2beta, use metrics
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+
   service:
     # -- Service type of the Ingress
     type: LoadBalancer
@@ -400,8 +423,30 @@ egress:
   enabled: false
   # -- Time for which old listener will still be active as draining
   drainTime: 30s
-  # -- Number of replicas of the Egress
+  # -- Number of replicas of the Egress. Ignored when autoscaling is enabled.
   replicas: 1
+
+  # Horizontal Pod Autoscaling configuration
+  autoscaling:
+    # -- Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster
+    enabled: false
+
+    # -- The minimum CP pods to allow
+    minReplicas: 2
+    # -- The max CP pods to scale to
+    maxReplicas: 5
+
+    # -- For clusters that don't support autoscaling/v2beta, autoscaling/v1 is used
+    targetCPUUtilizationPercentage: 80
+    # -- For clusters that do support autoscaling/v2beta, use metrics
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+
   service:
     # -- Service type of the Egress
     type: ClusterIP

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -59,8 +59,33 @@ controlPlane:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
 
-  # -- Affinity placement rule for the Kuma Control Plane pods
-  affinity: {}
+  # -- Affinity placement rule for the Kuma Control Plane pods.
+  # This is rendered as a template, so you can reference other helm variables or includes.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            # These match the selector labels used on the deployment.
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - '{{ include "kuma.name" . }}'
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                  - '{{ .Release.Name }}'
+              - key: app
+                operator: In
+                values:
+                  - '{{ include "kuma.name" . }}-control-plane'
+          topologyKey: kubernetes.io/hostname
+
+  # -- Topology spread constraints rule for the Kuma Control Plane pods
+  # Don't set this and affinity at the same time
+  topologySpreadConstraints:
 
   # -- Failure policy of the mutating webhook implemented by the Kuma Injector component
   injectorFailurePolicy: Fail
@@ -306,7 +331,33 @@ ingress:
     kubernetes.io/arch: amd64
 
   # -- Affinity placement rule for the Kuma Ingress pods
-  affinity: {}
+  # This is rendered as a template, so you can reference other helm variables
+  # or includes.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            # These match the selector labels used on the deployment.
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - '{{ include "kuma.name" . }}'
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                  - '{{ .Release.Name }}'
+              - key: app
+                operator: In
+                values:
+                  - kuma-ingress
+          topologyKey: kubernetes.io/hostname
+
+  # -- Topology spread constraints rule for the Kuma Mesh Ingress pods
+  # Don't set this and affinity at the same time
+  topologySpreadConstraints:
 
   # -- Security context at the pod level for ingress
   podSecurityContext: {}
@@ -357,8 +408,33 @@ egress:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
 
-  # -- Affinity placement rule for the Kuma Ingress pods
-  affinity: {}
+  # -- Affinity placement rule for the Kuma Egress pods.
+  # This is rendered as a template, so you can reference other helm variables or includes.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            # These match the selector labels used on the deployment.
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - '{{ include "kuma.name" . }}'
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                  - '{{ .Release.Name }}'
+              - key: app
+                operator: In
+                values:
+                  - kuma-egress
+          topologyKey: kubernetes.io/hostname
+
+  # -- Topology spread constraints rule for the Kuma Egress pods
+  # Don't set this and affinity at the same time
+  topologySpreadConstraints:
 
   # -- Security context at the pod level for egress
   podSecurityContext: {}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -207,6 +207,16 @@ controlPlane:
     repository: "kuma-cp"
     # -- Kuma CP Image tag. When not specified, the value is copied from global.tag
     tag:
+
+  # -- list of additional secret resources to create; for each specify the name and stringData
+  # name is rendered as a template using (tpl $)
+  additionalK8sSecrets:
+    # example
+    # - name: {{ include "kuma.name" . }}-extra-secret
+    #   stringData:
+    #     myKey: myValue
+    #     mySecondKey: mySecondValue
+
   # -- (list of { Env: string, Secret: string, Key: string }) Secrets to add as environment variables,
   # where `Env` is the name of the env variable,
   # `Secret` is the name of the Secret,

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -59,6 +59,12 @@ controlPlane:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
 
+  podDisruptionBudget:
+    # -- Whether or not to create a pod disruption budget
+    enabled: false
+    # -- The maximum number of unavailable pods allowed by the budget
+    maxUnavailable: 1
+
   # -- Affinity placement rule for the Kuma Control Plane pods.
   # This is rendered as a template, so you can reference other helm variables or includes.
   affinity:
@@ -330,6 +336,12 @@ ingress:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
 
+  podDisruptionBudget:
+    # -- Whether or not to create a pod disruption budget
+    enabled: false
+    # -- The maximum number of unavailable pods allowed by the budget
+    maxUnavailable: 1
+
   # -- Affinity placement rule for the Kuma Ingress pods
   # This is rendered as a template, so you can reference other helm variables
   # or includes.
@@ -407,6 +419,12 @@ egress:
   nodeSelector:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
+
+  podDisruptionBudget:
+    # -- Whether or not to create a pod disruption budget
+    enabled: false
+    # -- The maximum number of unavailable pods allowed by the budget
+    maxUnavailable: 1
 
   # -- Affinity placement rule for the Kuma Egress pods.
   # This is rendered as a template, so you can reference other helm variables or includes.


### PR DESCRIPTION
These are features we found we needed at GoodRx.

 - allow specifying resources for ingress
 - allow adding arbitrary secrets
 - allow defining kds secrets with helm
 - make service creation optional
 - allow adding extra labels to stuff
 - allow enabling autoscaling for ingress and egress
 - add pod disruption budgets
 - add optional topology spread constraints
 - add missing global-sync-service port